### PR TITLE
Getting reasonable x,y,z values

### DIFF
--- a/Detector/SCEPCAL/compact/SCEPCAL.xml
+++ b/Detector/SCEPCAL/compact/SCEPCAL.xml
@@ -28,7 +28,7 @@
     <readout name="SCEPCALreadout">
       <segmentation type="SCEPCALSegmentation"/>
       <!-- Mendatory to use the first 32 bits for tower infos & the last 32 bits for fiber/SiPM infos -->
-      <id>system:5,eta:-10,phi:10,depth:3,sipm:3,c:1,module:3</id>
+      <id>system:5,eta:-10,phi:12,depth:3,sipm:3,c:1,module:3</id>
     </readout>
   </readouts>
 

--- a/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
+++ b/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
@@ -74,8 +74,8 @@ namespace ddSCEPCAL {
       double dPhiBarrel   =2*M_PI/nPhiBarrel;
 
       // Make towers along theta (eta) and make rotations in phi each step (i.e. phi nested in theta)
-      for (int iTheta=0; iTheta<2*nThetaBarrel+1; iTheta++) {
-
+      for (int iTheta=0; iTheta<2*nThetaBarrel+2; iTheta++) {
+        if (iTheta == nThetaBarrel) continue;
         double thC =thetaSizeEndcap+(iTheta*dThetaBarrel);
 
         // Projective towers using EightPointSolids. see: https://root.cern.ch/doc/master/classTGeoArb8.html
@@ -122,8 +122,10 @@ namespace ddSCEPCAL {
         // Rotations in phi to place volumes
         for (int iPhi=0; iPhi<nPhiBarrel; iPhi++) {
 
-          auto crystalFId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1), iPhi, 1);
-          auto crystalRId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1), iPhi, 2);
+          //auto crystalFId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1), iPhi, 1);
+          auto crystalFId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) , iPhi, 1);
+          //auto crystalRId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1), iPhi, 2);
+          auto crystalRId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) , iPhi, 2);
 
           int crystalFId32=segmentation->getFirst32bits(crystalFId64);
           int crystalRId32=segmentation->getFirst32bits(crystalRId64);
@@ -149,35 +151,42 @@ namespace ddSCEPCAL {
           dd4hep::PlacedVolume crystalFp = towerAssemblyVol.placeVolume( crystalFVol, crystalFId32, Position(0,0,-Rdz/2) );
           dd4hep::PlacedVolume crystalRp = towerAssemblyVol.placeVolume( crystalRVol, crystalRId32, Position(0,0,Fdz/2) );
 
-          crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta *(iTheta>nThetaBarrel?-1:1));
+          //crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta *(iTheta>nThetaBarrel?-1:1));
+          crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta);
           crystalFp.addPhysVolID("phi", iPhi);
           crystalFp.addPhysVolID("depth", 1);
           crystalFp.addPhysVolID("system", 1);
 
-          crystalRp.addPhysVolID("eta", nThetaBarrel-iTheta *(iTheta>nThetaBarrel?-1:1));
+          //crystalRp.addPhysVolID("eta", nThetaBarrel-iTheta *(iTheta>nThetaBarrel?-1:1));
+          crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta );
           crystalRp.addPhysVolID("phi", iPhi);
           crystalRp.addPhysVolID("depth", 2);
           crystalRp.addPhysVolID("system", 1);
 
-          std::bitset<10> _eta((nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1));
+          //std::bitset<10> _eta((nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1));
+          std::bitset<10> _eta((nThetaBarrel-iTheta) );
           std::bitset<10> _phi(iPhi);
           std::bitset<3> depthF(1);
           std::bitset<3> depthR(2);
           std::bitset<32> id32F(crystalFId32);
           std::bitset<32> id32R(crystalRId32);
 
-//          VolIDs crystalFpVID = static_cast<VolIDs> crystalFp.VolIDs();
-//          VolIDs crystalRpVID = static_cast<VolIDs> crystalRp.VolIDs();
+          //VolIDs crystalFpVID = static_cast<VolIDs> crystalFp.VolIDs();
+          //VolIDs crystalRpVID = static_cast<VolIDs> crystalRp.VolIDs();
 
-//          std::cout << "B crystalF eta: " << ((nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1)) << " phi: " << iPhi << " depth: " << 1 << std::endl;
-//          std::cout << "B crystalF eta: " << _eta << " phi: " << _phi << " depth: " << depthF << std::endl;
-//          std::cout << "B crystalFId32: " << id32F << std::endl;
-//          std::cout << "B crystalF copyNum: " << crystalFp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalFpVID ) << std::endl;
+          //std::cout << "B crystalF eta: " << ((nThetaBarrel-iTheta) ) << " phi: " << iPhi << " depth: " << " 1 " << std::endl;
+          //std::cout << "B crystalF eta: " << _eta << " phi: " << _phi << " depth: " << depthF << std::endl;
+          //std::cout << "B crystalF eta: " << segmentation->Eta(crystalFId64) << " phi: " << segmentation->Phi(crystalFId64) << " depth: " << depthF << std::endl;
+          //std::cout << "B crystalFId32: " << id32F << std::endl;
+          //std::cout << "B crystalF copyNum: " <<  crystalFId32 << std::endl;
+          //std::cout << "B crystalF copyNum: " <<  crystalFId64 << std::endl;
+          //std::cout << "B crystalR copyNum: " << crystalRp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalRpVID ) << std::endl;
 
-//          std::cout << "B crystalR eta: " << ((nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1)) << " phi: " << iPhi << " depth: " << 2 << std::endl;
-//          std::cout << "B crystalR eta: " << _eta << " phi: " << _phi << " depth: " << depthR << std::endl;
-//          std::cout << "B crystalRId32: " << id32R << std::endl;
-//          std::cout << "B crystalR copyNum: " << crystalRp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalRpVID ) << std::endl;
+          //std::cout << "B crystalR eta: " << ((nThetaBarrel-iTheta) ) << " phi: " << iPhi << " depth: " << " 2 " << std::endl;
+          //std::cout << "B crystalR eta: " << _eta << " phi: " << _phi << " depth: " << depthR << std::endl;
+          //std::cout << "B crystalRId32: " << id32R << std::endl;
+          //std::cout << "B crystalR copyNum: " <<  crystalRId32 << std::endl;
+          //std::cout << "B crystalR copyNum: " << crystalRp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalRpVID ) << std::endl;
         }
       }
 
@@ -310,25 +319,25 @@ namespace ddSCEPCAL {
 
 
 
-//          std::cout << "E crystalF eta: " << (nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 1 << std::endl;
-//          std::cout << "E crystalF eta: " << _eta << " phi: " << _phi << " depth: " << depthF << std::endl;
-//          std::cout << "E crystalFId32: " << id32F << std::endl;
-//          std::cout << "E crystalF copyNum: " << crystalFp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalFp.VolIDs()) << std::endl;
+          //std::cout << "E crystalF eta: " << (nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 1 << std::endl;
+          //std::cout << "E crystalF eta: " << _eta << " phi: " << _phi << " depth: " << depthF << std::endl;
+          //std::cout << "E crystalFId32: " << id32F << std::endl;
+          //std::cout << "E crystalF copyNum: " << crystalFp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalFp.VolIDs()) << std::endl;
 
-//          std::cout << "E crystalR eta: " << (nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 2 << std::endl;
-//          std::cout << "E crystalR eta: " << _eta << " phi: " << _phi << " depth: " << depthR << std::endl;
-//          std::cout << "E crystalRId32: " << id32R << std::endl;
-//          std::cout << "E crystalR copyNum: " << crystalRp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalRp.VolIDs()) << std::endl;
+          //std::cout << "E crystalR eta: " << (nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 2 << std::endl;
+          //std::cout << "E crystalR eta: " << _eta << " phi: " << _phi << " depth: " << depthR << std::endl;
+          //std::cout << "E crystalRId32: " << id32R << std::endl;
+          //std::cout << "E crystalR copyNum: " << crystalRp.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString( crystalRp.VolIDs()) << std::endl;
 
-//          std::cout << "E crystalF1 eta: " << -(nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 1 << std::endl;
-//          std::cout << "E crystalF1 eta: " << _eta1 << " phi: " << _phi << " depth: " << depthF << std::endl;
-//          std::cout << "E crystalFId321: " << id32F1 << std::endl;
-//          std::cout << "E crystalF1 copyNum: " << crystalFp1.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString(crystalFp1.VolIDs()) << std::endl;
+          //std::cout << "E crystalF1 eta: " << -(nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 1 << std::endl;
+          //std::cout << "E crystalF1 eta: " << _eta1 << " phi: " << _phi << " depth: " << depthF << std::endl;
+          //std::cout << "E crystalFId321: " << id32F1 << std::endl;
+          //std::cout << "E crystalF1 copyNum: " << crystalFp1.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString(crystalFp1.VolIDs()) << std::endl;
 
-//          std::cout << "E crystalR1 eta: " << -(nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 2 << std::endl;
-//          std::cout << "E crystalR1 eta: " << _eta1 << " phi: " << _phi << " depth: " << depthR << std::endl;
-//          std::cout << "E crystalRId321: " << id32R1 << std::endl;
-//          std::cout << "E crystalR1 copyNum: " << crystalRp1.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString(crystalRp1.VolIDs()) << std::endl;
+          //std::cout << "E crystalR1 eta: " << -(nThetaBarrel+nThetaEndcap-iTheta) << " phi: " << iPhi << " depth: " << 2 << std::endl;
+          //std::cout << "E crystalR1 eta: " << _eta1 << " phi: " << _phi << " depth: " << depthR << std::endl;
+          //std::cout << "E crystalRId321: " << id32R1 << std::endl;
+          //std::cout << "E crystalR1 copyNum: " << crystalRp1.copyNumber() << " VolIDs: " << dd4hep::detail::tools::toString(crystalRp1.VolIDs()) << std::endl;
         }
 
 

--- a/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
+++ b/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
@@ -205,8 +205,10 @@ namespace ddSCEPCAL {
 
         // Skip crystals at low theta (near the beampipe) if the crystal face aspect ratio is over 15% of unity
         double centralHalfWidthActual = RinEndcap*sin(dPhiEndcap/2);
-
-        if (abs(1-y0/centralHalfWidthActual)>0.15) {continue;}
+        //std::cout << "For theta " << nThetaBarrel+nThetaEndcap-iTheta <<  ", crystal face aspect ratio " << abs(1-y0/centralHalfWidthActual) << std::endl;
+        if (abs(1-y0/centralHalfWidthActual)>0.14) { // changed to 14, since aspect ratio of first tower (42/-42) is 14.9
+          //std::cout << " More than 14% --> SKIPPING ... " << std::endl;
+          continue;}
 
         double x0y0 = (r0*cos(thC) +y0*sin(thC)) *tan(thC -dThetaEndcap/2.) *tan(dPhiEndcap/2.);
         double x1y0 = (r0*cos(thC) -y0*sin(thC)) *tan(thC +dThetaEndcap/2.) *tan(dPhiEndcap/2.);

--- a/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
+++ b/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
@@ -153,8 +153,8 @@ namespace ddSCEPCAL {
           crystalFp.addPhysVolID("phi", iPhi);
           crystalFp.addPhysVolID("depth", 1);
           crystalFp.addPhysVolID("system", 1);
-
-          crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta );
+          
+          crystalRp.addPhysVolID("eta", nThetaBarrel-iTheta );
           crystalRp.addPhysVolID("phi", iPhi);
           crystalRp.addPhysVolID("depth", 2);
           crystalRp.addPhysVolID("system", 1);

--- a/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
+++ b/Detector/SCEPCAL/src/SCEPCALConstructor.cpp
@@ -74,7 +74,7 @@ namespace ddSCEPCAL {
       double dPhiBarrel   =2*M_PI/nPhiBarrel;
 
       // Make towers along theta (eta) and make rotations in phi each step (i.e. phi nested in theta)
-      for (int iTheta=0; iTheta<2*nThetaBarrel+2; iTheta++) {
+      for (int iTheta=0; iTheta<2*nThetaBarrel+1; iTheta++) {
         if (iTheta == nThetaBarrel) continue;
         double thC =thetaSizeEndcap+(iTheta*dThetaBarrel);
 
@@ -122,9 +122,7 @@ namespace ddSCEPCAL {
         // Rotations in phi to place volumes
         for (int iPhi=0; iPhi<nPhiBarrel; iPhi++) {
 
-          //auto crystalFId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1), iPhi, 1);
           auto crystalFId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) , iPhi, 1);
-          //auto crystalRId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1), iPhi, 2);
           auto crystalRId64=segmentation->setVolumeID(1, (nThetaBarrel-iTheta) , iPhi, 2);
 
           int crystalFId32=segmentation->getFirst32bits(crystalFId64);
@@ -151,19 +149,16 @@ namespace ddSCEPCAL {
           dd4hep::PlacedVolume crystalFp = towerAssemblyVol.placeVolume( crystalFVol, crystalFId32, Position(0,0,-Rdz/2) );
           dd4hep::PlacedVolume crystalRp = towerAssemblyVol.placeVolume( crystalRVol, crystalRId32, Position(0,0,Fdz/2) );
 
-          //crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta *(iTheta>nThetaBarrel?-1:1));
           crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta);
           crystalFp.addPhysVolID("phi", iPhi);
           crystalFp.addPhysVolID("depth", 1);
           crystalFp.addPhysVolID("system", 1);
 
-          //crystalRp.addPhysVolID("eta", nThetaBarrel-iTheta *(iTheta>nThetaBarrel?-1:1));
           crystalFp.addPhysVolID("eta", nThetaBarrel-iTheta );
           crystalRp.addPhysVolID("phi", iPhi);
           crystalRp.addPhysVolID("depth", 2);
           crystalRp.addPhysVolID("system", 1);
 
-          //std::bitset<10> _eta((nThetaBarrel-iTheta) *(iTheta>nThetaBarrel?-1:1));
           std::bitset<10> _eta((nThetaBarrel-iTheta) );
           std::bitset<10> _phi(iPhi);
           std::bitset<3> depthF(1);

--- a/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
+++ b/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
@@ -50,17 +50,23 @@ namespace DDSegmentation {
           int copyNum = (int)cID;
 
           if (fPositionOf.count(copyNum) == 0) { //Add if not found
-            int system=(copyNum)&(32-1);
+            //int system=(copyNum)&(32-1);
             //int nEta_in=(copyNum>>5)&(1024-1);
-            int nEta_in=Eta(copyNum);
-            int nPhi_in=(copyNum>>15)&(1024-1);
-            int nDepth_in=(copyNum>>25)&(8-1);
+            //int nPhi_in=(copyNum>>15)&(1024-1);
+            //int nDepth_in=(copyNum>>25)&(8-1);
 
-            double EBz=2.25;
-            double Rin=2.0;
-            double nomfw=0.1;
-            double Fdz=0.05;
-            double Rdz=0.15;
+            int system=System(copyNum);
+            int nEta_in=Eta(copyNum);
+            int nPhi_in=Phi(copyNum);
+            int nDepth_in=Depth(copyNum);
+
+
+            // now in mm
+            double EBz=2250;
+            double Rin=2000;
+            double nomfw=100;
+            double Fdz=50;
+            double Rdz=150;
 
             int nThetaBarrel=floor(EBz/nomfw);
             int nThetaEndcap=floor(Rin/nomfw);
@@ -69,12 +75,9 @@ namespace DDSegmentation {
             double dTheta=(M_PI/2)/(nThetaBarrel+nThetaEndcap);
             double dPhi=2*M_PI/nPhi;
 
-            int nTheta = nEta_in>0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
-            //std::cout << "This is nEta_in :: " << nEta_in << std::endl;
-            //std::cout << "So this is nTheta :: " << nTheta << std::endl;
+            int nTheta = nEta_in; //>0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
             double thC=nTheta*dTheta;
 
-            //std::cout << "So this is thC :: " << nTheta*dTheta << std::endl;
             double phi=nPhi_in*dPhi;
 
             double r0=EBz/cos(thC);
@@ -87,10 +90,11 @@ namespace DDSegmentation {
             double y=R*sin(thC)*sin(phi);
             double z= thC>0 ? R*cos(thC):-R*cos(thC);
 
-            
-            //std::cout << "And finally R :: " << R << std::endl;
-            //std::cout << "And finally cos :: " << cos(thC) << std::endl;
-            //std::cout << "And finally Z :: " << z << std::endl;
+            //std::cout << "These are nEta_in :: " << nEta_in << " Phi_in ::" << nPhi_in << " Depth :: " << nDepth_in << std::endl;
+            //std::cout << "So this is nTheta :: " << nTheta << std::endl;
+            //std::cout << "r1 :: " <<  r0+Fdz << " r2:: " << r1+Rdz << std::endl;
+            //std::cout << "... thC :: " << nTheta*dTheta  <<  "and  R :: " << R <<  "... finally cos :: " << cos(thC) << std::endl;
+            //std::cout << "to get  Z :: " << z << std::endl;
             Vector3D position(x, y, z);
             fPositionOf.emplace(copyNum,position);
           }

--- a/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
+++ b/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
@@ -70,11 +70,11 @@ namespace DDSegmentation {
             double dPhi=2*M_PI/nPhi;
 
             int nTheta = nEta_in>0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
-            std::cout << "This is nEta_in :: " << nEta_in << std::endl;
-            std::cout << "So this is nTheta :: " << nTheta << std::endl;
+            //std::cout << "This is nEta_in :: " << nEta_in << std::endl;
+            //std::cout << "So this is nTheta :: " << nTheta << std::endl;
             double thC=nTheta*dTheta;
 
-            std::cout << "So this is thC :: " << nTheta*dTheta << std::endl;
+            //std::cout << "So this is thC :: " << nTheta*dTheta << std::endl;
             double phi=nPhi_in*dPhi;
 
             double r0=EBz/cos(thC);
@@ -88,9 +88,9 @@ namespace DDSegmentation {
             double z= thC>0 ? R*cos(thC):-R*cos(thC);
 
             
-            std::cout << "And finally R :: " << R << std::endl;
-            std::cout << "And finally cos :: " << cos(thC) << std::endl;
-            std::cout << "And finally Z :: " << z << std::endl;
+            //std::cout << "And finally R :: " << R << std::endl;
+            //std::cout << "And finally cos :: " << cos(thC) << std::endl;
+            //std::cout << "And finally Z :: " << z << std::endl;
             Vector3D position(x, y, z);
             fPositionOf.emplace(copyNum,position);
           }

--- a/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
+++ b/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
@@ -51,12 +51,13 @@ namespace DDSegmentation {
 
           if (fPositionOf.count(copyNum) == 0) { //Add if not found
             int system=(copyNum)&(32-1);
-            int nEta_in=(copyNum>>5)&(1024-1);
+            //int nEta_in=(copyNum>>5)&(1024-1);
+            int nEta_in=Eta(copyNum);
             int nPhi_in=(copyNum>>15)&(1024-1);
             int nDepth_in=(copyNum>>25)&(8-1);
 
-            double EBz=2.0;
-            double Rin=1.5;
+            double EBz=2.25;
+            double Rin=2.0;
             double nomfw=0.1;
             double Fdz=0.05;
             double Rdz=0.15;
@@ -68,19 +69,28 @@ namespace DDSegmentation {
             double dTheta=(M_PI/2)/(nThetaBarrel+nThetaEndcap);
             double dPhi=2*M_PI/nPhi;
 
-            int nTheta=nEta_in>0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : (nThetaBarrel+nThetaEndcap)-nEta_in;
+            int nTheta = nEta_in>0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
+            std::cout << "This is nEta_in :: " << nEta_in << std::endl;
+            std::cout << "So this is nTheta :: " << nTheta << std::endl;
             double thC=nTheta*dTheta;
+
+            std::cout << "So this is thC :: " << nTheta*dTheta << std::endl;
             double phi=nPhi_in*dPhi;
 
             double r0=EBz/cos(thC);
+
             double r1=r0+Fdz;
             double r2=r1+Rdz;
 
             double R=nDepth_in==1 ? (r0+r1)/2 : (r1+r2)/2;
             double x=R*sin(thC)*cos(phi);
             double y=R*sin(thC)*sin(phi);
-            double z=R*cos(thC);
+            double z= thC>0 ? R*cos(thC):-R*cos(thC);
 
+            
+            std::cout << "And finally R :: " << R << std::endl;
+            std::cout << "And finally cos :: " << cos(thC) << std::endl;
+            std::cout << "And finally Z :: " << z << std::endl;
             Vector3D position(x, y, z);
             fPositionOf.emplace(copyNum,position);
           }
@@ -120,6 +130,13 @@ namespace DDSegmentation {
             VolumeID PhiId = static_cast<VolumeID>(Phi);
             VolumeID DepthId = static_cast<VolumeID>(Depth);
             VolumeID vID = 0;
+
+            //std::cout << " In setVolumeID:: " << std::endl;
+            //std::cout << " EtaID:: " << EtaId <<std::endl;
+            //std::cout << " PhiID:: " << PhiId <<std::endl;
+            //std::cout << " DepthID:: " << DepthId <<std::endl;
+
+
             _decoder->set(vID, fSystemId, SystemId);
             _decoder->set(vID, fEtaId, EtaId);
             _decoder->set(vID, fPhiId, PhiId);
@@ -132,11 +149,19 @@ namespace DDSegmentation {
         }
 
         CellID SCEPCALSegmentation::setCellID(int System, int Eta, int Phi, int Depth) const {
-          VolumeID SystemId = static_cast<VolumeID>(System);
-          VolumeID EtaId = static_cast<VolumeID>(Eta);
+            VolumeID SystemId = static_cast<VolumeID>(System);
+            VolumeID EtaId = static_cast<VolumeID>(Eta);
             VolumeID PhiId = static_cast<VolumeID>(Phi);
             VolumeID DepthId = static_cast<VolumeID>(Depth);
             VolumeID vID = 0;
+
+            //std::cout << " In setCellID:: " << std::endl;
+            //std::cout << " EtaID:: " << EtaId <<std::endl;
+            //std::cout << " PhiID:: " << PhiId <<std::endl;
+            //std::cout << " DepthID:: " << DepthId <<std::endl;
+
+
+
             _decoder->set(vID, fSystemId, SystemId);
             _decoder->set(vID, fEtaId, EtaId);
             _decoder->set(vID, fPhiId, PhiId);

--- a/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
+++ b/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
@@ -74,27 +74,35 @@ namespace DDSegmentation {
 
             double dTheta=(M_PI/2)/(nThetaBarrel+nThetaEndcap);
             double dPhi=2*M_PI/nPhi;
-
-            int nTheta = nEta_in >0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
+             
+            // added a 1 since we are counting from 1 not from 0 (?)
+            int nTheta = nEta_in >0 ? (nThetaBarrel+nThetaEndcap+1)-nEta_in : -((nThetaBarrel+nThetaEndcap+1)+nEta_in);
             double thC=nTheta*dTheta;
 
             double phi=nPhi_in*dPhi;
 
-            double r0=EBz/cos(thC);
+            //double r0=EBz/cos(thC); // May be this is the case for the endcaps
+            // for EE fixed proj along EBz of r0, while for EB proj along transv plane is fixed:
+            double r0 = abs(nEta_in) > nThetaBarrel ? r0=EBz/cos(thC) : Rin/abs(sin(thC));
 
-            double r1=r0+Fdz;
-            double r2=r1+Rdz;
+            //double r1=r0+Fdz;
+            //double r2=r1+Rdz;
+            double rF=r0+Fdz/2; // r is connecting the IP to center of crystal
+            double rR=rF+Rdz/2;
 
-            double R=nDepth_in==1 ? (r0+r1)/2 : (r1+r2)/2;
+
+            //double R=nDepth_in==1 ? (r0+r1)/2 : (r1+r2)/2;
+            double R=nDepth_in==1 ? rF : rR;
             double x=R*sin(thC)*cos(phi);
             double y=R*sin(thC)*sin(phi);
             double z= thC>0 ? R*cos(thC):-R*cos(thC);
 
             //std::cout << "These are nEta_in :: " << nEta_in << " Phi_in ::" << nPhi_in << " Depth :: " << nDepth_in << std::endl;
             //std::cout << "So this is nTheta :: " << nTheta << std::endl;
-            //std::cout << "r1 :: " <<  r0+Fdz << " r2:: " << r1+Rdz << std::endl;
+            //std::cout << "rF :: " << rF << " rR:: " << rR << std::endl;
             //std::cout << "... thC :: " << nTheta*dTheta  <<  "and  R :: " << R <<  "... finally cos :: " << cos(thC) << std::endl;
             //std::cout << "to get  Z :: " << z << std::endl;
+
             Vector3D position(x, y, z);
             fPositionOf.emplace(copyNum,position);
           }

--- a/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
+++ b/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
@@ -75,7 +75,7 @@ namespace DDSegmentation {
             double dTheta=(M_PI/2)/(nThetaBarrel+nThetaEndcap);
             double dPhi=2*M_PI/nPhi;
 
-            int nTheta = nEta_in; //>0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
+            int nTheta = nEta_in >0 ? (nThetaBarrel+nThetaEndcap)-nEta_in : -((nThetaBarrel+nThetaEndcap)+nEta_in);
             double thC=nTheta*dTheta;
 
             double phi=nPhi_in*dPhi;

--- a/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
+++ b/Detector/SCEPCALsegmentation/src/SCEPCALSegmentation.cpp
@@ -75,15 +75,17 @@ namespace DDSegmentation {
             double dTheta=(M_PI/2)/(nThetaBarrel+nThetaEndcap);
             double dPhi=2*M_PI/nPhi;
              
-            // added a 1 since we are counting from 1 not from 0 (?)
-            int nTheta = nEta_in >0 ? (nThetaBarrel+nThetaEndcap+1)-nEta_in : -((nThetaBarrel+nThetaEndcap+1)+nEta_in);
+            // nTheta always positive, so that thC is going from 0 to pi.
+            // [0,pi/2) --> z, eta positive ; (pi/2,pi] --> z,eta negative; pi/2 (cos(theta) = 0) is excluded
+            int nTheta = (nThetaBarrel+nThetaEndcap)-nEta_in;
             double thC=nTheta*dTheta;
-
+              
+            //phi should run form 0 to 2pi, so that x,y are both neg and positive.
             double phi=nPhi_in*dPhi;
 
             //double r0=EBz/cos(thC); // May be this is the case for the endcaps
             // for EE fixed proj along EBz of r0, while for EB proj along transv plane is fixed:
-            double r0 = abs(nEta_in) > nThetaBarrel ? r0=EBz/cos(thC) : Rin/abs(sin(thC));
+            double r0 = abs(nEta_in) > nThetaBarrel ? EBz/abs(cos(thC)) : Rin/abs(sin(thC));
 
             //double r1=r0+Fdz;
             //double r2=r1+Rdz;
@@ -95,13 +97,14 @@ namespace DDSegmentation {
             double R=nDepth_in==1 ? rF : rR;
             double x=R*sin(thC)*cos(phi);
             double y=R*sin(thC)*sin(phi);
-            double z= thC>0 ? R*cos(thC):-R*cos(thC);
+            double z=R*cos(thC);
 
             //std::cout << "These are nEta_in :: " << nEta_in << " Phi_in ::" << nPhi_in << " Depth :: " << nDepth_in << std::endl;
-            //std::cout << "So this is nTheta :: " << nTheta << std::endl;
+            //std::cout << "So these are nTheta :: " << nTheta << "and nPhi:: "<< nPhi_in << std::endl;
             //std::cout << "rF :: " << rF << " rR:: " << rR << std::endl;
-            //std::cout << "... thC :: " << nTheta*dTheta  <<  "and  R :: " << R <<  "... finally cos :: " << cos(thC) << std::endl;
-            //std::cout << "to get  Z :: " << z << std::endl;
+            //std::cout << "... theta :: " << thC <<  "and  R :: " << R <<  "... finally cos(theta),sin(theta) :: " << cos(thC) << "," << sin(thC) << std::endl;
+            //std::cout << "... phi   :: " << phi <<  "and  R :: " << R <<  "... finally cos(phi),sin(phi) :: " << cos(phi) << "," <<  sin(phi) << std::endl;
+            //std::cout << "to get  z=R*cos(theta)= " << z << " and y=R*sin(theta)*sin(phi)= " << y <<  " and x=R*sin(theta)*cos(phi)= " << x << std::endl;
 
             Vector3D position(x, y, z);
             fPositionOf.emplace(copyNum,position);

--- a/SCEPCALsim/SCEPCALsimG4Full/src/components/SimG4OpticalPhysicsList.cpp
+++ b/SCEPCALsim/SCEPCALsimG4Full/src/components/SimG4OpticalPhysicsList.cpp
@@ -36,7 +36,7 @@ G4VModularPhysicsList* SimG4OpticalPhysicsList::physicsList() {
   auto* opticalParams = G4OpticalParameters::Instance();
   opticalParams->SetBoundaryInvokeSD(true);
   opticalParams->SetProcessActivation("Cerenkov",true);
-  opticalParams->SetProcessActivation("Scintillation",true);
+  opticalParams->SetProcessActivation("Scintillation",false);
   opticalParams->SetCerenkovTrackSecondariesFirst(true);
   opticalParams->SetScintTrackSecondariesFirst(true);
 

--- a/SCEPCALsim/SCEPCALsimG4Full/src/lib/SimG4SCEPCALSteppingAction.cpp
+++ b/SCEPCALsim/SCEPCALsimG4Full/src/lib/SimG4SCEPCALSteppingAction.cpp
@@ -183,12 +183,17 @@ void SimG4SCEPCALSteppingAction::accumulate(unsigned int                    &pre
 
     auto pos = pSeg->myPosition(copyNum64);
 
-    if (fDebugLevel<6) {
+    if (fDebugLevel<2) {
       std::cout << "        Accumulate Position: x: "<<pos.x()*CLHEP::millimeter
                 << " y: "<<pos.y()*CLHEP::millimeter
                 << " z: "<<pos.z()*CLHEP::millimeter
                 << std::endl;
     }
+
+    //simEdep.setPosition( { static_cast<float>(pos.x()/CLHEP::centimeter*CLHEP::millimeter),
+    //                       static_cast<float>(pos.y()/CLHEP::centimeter*CLHEP::millimeter),
+    //                       static_cast<float>(pos.z()/CLHEP::centimeter*CLHEP::millimeter) } );
+
 
     simEdep.setPosition( { static_cast<float>(pos.x()*CLHEP::millimeter),
                            static_cast<float>(pos.y()*CLHEP::millimeter),


### PR DESCRIPTION
1. In the SCEPCal XML, the bits related to Phi changed from 10 to 12 to allow 5x5 mm^2 crystal geometry.

2. In `SCEPCalConstructor.cpp` :
- in the EB loop:
    -  set eta to nThetaBarrel-iTheta, so that eta runs from -nThetaBarrel to nThetaBarrel;
    -  skipping the point of eta == 0, which was causing the values of x,y being 10^16 and z = EBz, e.g. of wrong output:
```
        This is nEta_in :: 0
        So this is nTheta :: -42
        So this is thC :: -1.5708
        And finally R :: 3.67453e+16
        And finally cos :: 6.12323e-17
        And finally Z :: -2.25
```


   
- in the EE loop:
    -  crystal face aspect ratio limit set to 14% of unity (so that also first tower, which has a ratio of about 14.9, is skipped)

3. In `SCEPCalSegmentation.cpp` in `myPosition` function:
- using the existing bit decoder functions (e.g. System(copyNum), Eta(copyNum), etc.) instead of "manual" reading:
    -  adapt automatically to the changes in the readout XML bit encoding, no need to change the cpp code as well.
    -  for negatively defined values (eta ones), the manually inline readout (e.g. system=(copyNum)&(32-1)) does not work correctly. Indeed, it misinterprets the 10 bits related to negative values of eta as positive, hence producing values of eta around 1000. An example of the wrong output:

```
                B crystalF eta: -15 phi: 0 depth:  1
 		B crystalF eta: 1111110001 phi: 0000000000 depth: 001
 		B crystalFId32: 00000010000000000111111000100001
 		B crystalF copyNum: 33586721
                 [...]
 		This is nEta_in :: 1009
```
- moved geometry parameters to mm (instead of meters) to be consistent with `CLHEP::millimeter` in the `SteppingAction`;
-  r0 (connecting IP to the center of the crystal) defined differently for EE, EB:  
    -  for EE fixed proj along EBz of r0, so r0 = EBz/abs(cos(thC));
    -  while for EB projection along the transverse plane is fixed, so r0 = Rin/abs(sin(thC)).

-   `nTheta = nThetaBarrel+nThetaEndcap - Eta_in` so that positive Eta_in are mapped to nTheta in [0,nThetaBarrel+nThetaEndcap-1], negative Eta_in are mapped to [nThetaBarrel+nThetaEndcap+1, 2*(nThetaBarrel+nThetaEndcap)] and finally theta (thC) is always positive and defined in the [0, pi] range:
     -  cos(theta) can be > or < 0 --> z = R cos(theta) can be > or < 0;
     -  sin(theta) always > 0 -->  the projection on the transverse plane (x,y) Rsin(theta)  is > 0; then x and y sings depend only on phi (defined in [0,2*pi]), since x = R sin(theta) cos(phi) and y= R sin(theta) sin(phi).
Output e.g.:
```
    These are nEta_in :: -6 Phi_in ::52 Depth :: 1
    So these are nTheta :: 48and nPhi:: 52
     rF :: 2076.43 rR:: 2151.43
      ... theta :: 1.7952and  R :: 2076.43... finally cos(theta),sin(theta) :: -0.222521,0.974928
      ... phi   :: 2.61381and  R :: 2076.43... finally cos(phi),sin(phi) :: -0.863923,0.503623
      to get  z=R*cos(theta)= -462.05 and y=R*sin(theta)*sin(phi)= 1019.52 and x=R*sin(theta)*cos(phi)= -1748.9
      These are nEta_in :: 21 Phi_in ::22 Depth :: 1
      So these are nTheta :: 21and nPhi:: 22
      rF :: 2853.43 rR:: 2928.43
       ... theta :: 0.785398and  R :: 2853.43... finally cos(theta),sin(theta) :: 0.707107,0.707107
       ... phi   :: 1.10584and  R :: 2853.43... finally cos(phi),sin(phi) :: 0.448383,0.893841
      to get  z=R*cos(theta)= 2017.68 and y=R*sin(theta)*sin(phi)= 1803.48 and x=R*sin(theta)*cos(phi)= 904.693

```
4. In PhysicsList set the scintillation process to false as it speeds up the calculations.

Now getting x,y,z values in the meters range, as expected.
See plots: https://fcetorel.web.cern.ch/fcetorel/SCEPCal_Sim/test_plots/checkCellId/pullReq_30Ott23/

